### PR TITLE
Display warning if trying to access compendium that is not visible or…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+* 2020/08/21 - Display warning if trying to access compendium that is not visible or locked, and don't try to update reference.  Only update embedded object if differences are detected.
 * 2020/08/21 - Fixed updating embedded objects on Actors.
 * 2020/08/21 - Removed 0.7.1 compatibility as it was found the expanded data structure causes issues with exporting and importing scenes.
 * 2020/08/21 - Fixed issue where sometimes path is an empty string during import image function.

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "adventure-import-export",
   "title": "Adventure Importer / Exporter",
   "description": "Allows import and export of adventures (including all Foundy VTT Assets).",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "author": "Chris Stadther",
   "minimumCoreVersion": "0.6.0",
   "compatibleCoreVersion": "0.6.5",
@@ -31,6 +31,6 @@
   "packs": [],
   "url": "https://github.com/cstadther/adventure-import-export",
   "manifest": "https://raw.githubusercontent.com/cstadther/adventure-import-export/master/module.json",
-  "download": "https://github.com/cstadther/adventure-import-export/archive/0.4.7.zip",
+  "download": "https://github.com/cstadther/adventure-import-export/archive/0.4.8.zip",
   "license" : "LICENSE"
 }


### PR DESCRIPTION
… locked, and don't try to update reference.

Only update embedded object if differences are detected.
Update to release 0.4.8