### PR TITLE
Fixes querystring parameter issue with file paths

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -120,20 +120,21 @@ export default class Helpers {
         // this file was flagged as core data, just replace name.
         return path.replace(/\*/g, "");
       } else {
-        let adventurePath = (adventure.name).replace(/[^a-z0-9]/gi, '_');
-        if(!CONFIG.AIE.TEMPORARY.import[path]) {
-          let filename = path.replace(/^.*[\\\/]/, '').replace(/\?(.*)/, '');
-          
-          await Helpers.verifyPath("data", `worlds/${game.world.name}/adventures/${adventurePath}/${path.replace(filename, "")}`);
+        const adventurePath = (adventure.name).replace(/[^a-z0-9]/gi, '_');
+        const targetPath = path.replace(/[\\\/][^\\\/]+$/, '');
+        const filename = path.replace(/^.*[\\\/]/, '').replace(/\?(.*)/, '');
+        
+        if(!CONFIG.AIE.TEMPORARY.import[path]) {         
+          await Helpers.verifyPath("data", `worlds/${game.world.name}/adventures/${adventurePath}/${targetPath}`);
           const img = await zip.file(path).async("uint8array");
           const i = new File([img], filename);
-          await Helpers.UploadFile("data", `worlds/${game.world.name}/adventures/${adventurePath}/${path.replace(filename, "")}`, i, { bucket: null })
+          await Helpers.UploadFile("data", `worlds/${game.world.name}/adventures/${adventurePath}/${targetPath}`, i, { bucket: null })
           CONFIG.AIE.TEMPORARY.import[path] = true;
         } else {
           Helpers.logger.debug(`File already imported ${path}`);  
         }
         
-        return `worlds/${game.world.id}/adventures/${adventurePath}/${path}`;
+        return `worlds/${game.world.id}/adventures/${adventurePath}/${targetPath}/${filename}`;
       }
     } catch (err) {
       Helpers.logger.error(`Error importing image file ${path} : ${err.message}`);


### PR DESCRIPTION
There is an issue with the current Importer implementation that results in the path generated on the file system including (incorrectly) any querystring present in the file path. This results in `404 Not Found` errors when attempting to retrieve the image.

**Example:**
1. Avatar path: `actor/images/0FKncdMTp0uHEWsy/Ash_Zombie.Avatar.png?1607741617110`
2. Imported Path: `.../actor/images/0FKncdMTp0uHEWsy/?1607741617110/Ash_Zombie.Avatar.png`

This results in a 404 error when attempting to retrieve the image in the UI, as it was using the original path as a reference (without the querystring folder):

```html
<!-- Sample -->
<img src="actor/images/0FKncdMTp0uHEWsy/Ash_Zombie.Avatar.png?1607741617110" />
```
This PR creates a separate `targetPath` variable for tracking where the file is stored on the file system, which strips out both the file name and the querystring parameter when verifying the folders.