### PR TITLE
Continued support for 0.8.X on adventure import

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,10 +2,10 @@
   "name": "adventure-import-export",
   "title": "Adventure Importer / Exporter",
   "description": "Allows import and export of adventures (including all Foundry VTT Assets).",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "author": "Chris Stadther",
-  "minimumCoreVersion": "0.6.0",
-  "compatibleCoreVersion": "0.7.9",
+  "minimumCoreVersion": "0.8.0",
+  "compatibleCoreVersion": "0.8.7",
   "languages" : [
     {
       "lang": "en",
@@ -32,6 +32,6 @@
   "packs": [],
   "url": "https://github.com/cstadther/adventure-import-export",
   "manifest": "https://raw.githubusercontent.com/cstadther/adventure-import-export/master/module.json",
-  "download": "https://github.com/cstadther/adventure-import-export/archive/0.6.0.zip",
+  "download": "https://github.com/cstadther/adventure-import-export/archive/0.7.0.zip",
   "license" : "LICENSE"
 }

--- a/src/adventure-import.js
+++ b/src/adventure-import.js
@@ -409,7 +409,7 @@ export default class AdventureModuleImport extends FormApplication {
 
                           if(Object.keys(itemUpdateDate).length > 0) {
                             Helpers.logger.debug(`Updating Owned item ${updatedDataUpdates.items[i]._id} for ${item} with: `, itemUpdateDate)
-                            await obj.update("OwnedItem", {_id: updatedDataUpdates.items[i]._id, ...itemUpdateDate });
+                            await obj.updateEmbeddedDocuments("OwnedItem", [{_id: updatedDataUpdates.items[i]._id, ...itemUpdateDate }]);
                           }
                         }
                       }

--- a/src/adventure-import.js
+++ b/src/adventure-import.js
@@ -201,7 +201,7 @@ export default class AdventureModuleImport extends FormApplication {
                       if(token.data.actorId) {
                         const actor = Helpers.findEntityByImportId("actors", token.data.actorId);
                         if(actor) {
-                          await obj.updateEmbeddedDocuments("Token", [{_id: token._id, actorId : actor._id}]);
+                          await obj.updateEmbeddedDocuments("Token", [{_id: token.id, actorId : actor._id}]);
                         }
                       }
                     });
@@ -209,7 +209,7 @@ export default class AdventureModuleImport extends FormApplication {
                       if(note.data.entryId) {
                         const journalentry = Helpers.findEntityByImportId("journal", note.data.entryId);
                         if(journalentry) {
-                          await obj.updateEmbeddedDocuments("Note", [{_id: note._id, entryId : journalentry._id}]);
+                          await obj.updateEmbeddedDocuments("Note", [{_id: note.id, entryId : journalentry._id}]);
                         }
                       }
                     });

--- a/src/adventure-import.js
+++ b/src/adventure-import.js
@@ -197,19 +197,19 @@ export default class AdventureModuleImport extends FormApplication {
                 switch (obj.documentName) {
                   case "Scene":
                     // this is a scene we need to update links to all items 
-                    await Helpers.asyncForEach(obj.data.tokens, async token => {
-                      if(token.actorId) {
-                        const actor = Helpers.findEntityByImportId("actors", token.actorId);
+                    await Helpers.asyncForEach(obj.data.tokens.contents, async token => {
+                      if(token.data.actorId) {
+                        const actor = Helpers.findEntityByImportId("actors", token.data.actorId);
                         if(actor) {
-                          await obj.update("Token", {_id: token._id, actorId : actor._id});
+                          await obj.updateEmbeddedDocuments("Token", [{_id: token._id, actorId : actor._id}]);
                         }
                       }
                     });
-                    await Helpers.asyncForEach(obj.data.notes, async note => {
-                      if(note.entryId) {
-                        const journalentry = Helpers.findEntityByImportId("journal", note.entryId);
+                    await Helpers.asyncForEach(obj.data.notes.contents, async note => {
+                      if(note.data.entryId) {
+                        const journalentry = Helpers.findEntityByImportId("journal", note.data.entryId);
                         if(journalentry) {
-                          await obj.update("Note", {_id: note._id, entryId : journalentry._id});
+                          await obj.updateEmbeddedDocuments("Note", [{_id: note._id, entryId : journalentry._id}]);
                         }
                       }
                     });
@@ -714,7 +714,7 @@ export default class AdventureModuleImport extends FormApplication {
         case "Actor" : 
           if(!Helpers.findEntityByImportId("actors", data._id)) {
             let actor = await Actor.create(data);
-            await actor.update({[`data.token.actorId`] : actor.data._id})
+            await actor.update({[`data.token.data.actorId`] : actor.data._id})
             if(needRevisit) {
               this._itemsToRevisit.push(`Actor.${actor.data._id}`);
             }

--- a/src/adventure-import.js
+++ b/src/adventure-import.js
@@ -669,7 +669,7 @@ export default class AdventureModuleImport extends FormApplication {
           })
         }
       }
-
+      
       data.flags.importid = data._id;
       
       if(typeName !== "Playlist" && typeName !== "Compendium") {

--- a/src/adventure-import.js
+++ b/src/adventure-import.js
@@ -194,14 +194,14 @@ export default class AdventureModuleImport extends FormApplication {
                 const obj = await fromUuid(item);
                 let rawData;
                 let updatedData = {};
-                switch (obj.entity) {
+                switch (obj.documentName) {
                   case "Scene":
                     // this is a scene we need to update links to all items 
                     await Helpers.asyncForEach(obj.data.tokens, async token => {
                       if(token.actorId) {
                         const actor = Helpers.findEntityByImportId("actors", token.actorId);
                         if(actor) {
-                          await obj.updateEmbeddedEntity("Token", {_id: token._id, actorId : actor._id});
+                          await obj.update("Token", {_id: token._id, actorId : actor._id});
                         }
                       }
                     });
@@ -209,7 +209,7 @@ export default class AdventureModuleImport extends FormApplication {
                       if(note.entryId) {
                         const journalentry = Helpers.findEntityByImportId("journal", note.entryId);
                         if(journalentry) {
-                          await obj.updateEmbeddedEntity("Note", {_id: note._id, entryId : journalentry._id});
+                          await obj.update("Note", {_id: note._id, entryId : journalentry._id});
                         }
                       }
                     });
@@ -400,7 +400,7 @@ export default class AdventureModuleImport extends FormApplication {
                     const updatedDataUpdates = JSON.parse(secondPassRawData);
                     const diff = Helpers.diff(obj.data, updatedDataUpdates);
                     
-                    if(diff.items && obj.entity === "Actor" && diff.items.length > 0) {
+                    if(diff.items && obj.documentName === "Actor" && diff.items.length > 0) {
                       // the object has embedded items that need to be updated seperately.
 
                       for(let i = 0; i < updatedDataUpdates.items.length; i+=1) {
@@ -409,7 +409,7 @@ export default class AdventureModuleImport extends FormApplication {
 
                           if(Object.keys(itemUpdateDate).length > 0) {
                             Helpers.logger.debug(`Updating Owned item ${updatedDataUpdates.items[i]._id} for ${item} with: `, itemUpdateDate)
-                            await obj.updateEmbeddedEntity("OwnedItem", {_id: updatedDataUpdates.items[i]._id, ...itemUpdateDate });
+                            await obj.update("OwnedItem", {_id: updatedDataUpdates.items[i]._id, ...itemUpdateDate });
                           }
                         }
                       }

--- a/src/common.js
+++ b/src/common.js
@@ -124,12 +124,18 @@ export default class Helpers {
         const targetPath = path.replace(/[\\\/][^\\\/]+$/, '');
         const filename = path.replace(/^.*[\\\/]/, '').replace(/\?(.*)/, '');
         
-        if(!CONFIG.AIE.TEMPORARY.import[path]) {
-          await Helpers.verifyPath("data", `worlds/${game.world.name}/adventures/${adventurePath}/${targetPath}`);
-          const img = await zip.file(path).async("uint8array");
-          const i = new File([img], filename);
-          await Helpers.UploadFile("data", `worlds/${game.world.name}/adventures/${adventurePath}/${targetPath}`, i, { bucket: null })
-          CONFIG.AIE.TEMPORARY.import[path] = true;
+        if(!CONFIG.AIE.TEMPORARY.import[path]) {         
+          await Helpers.verifyPath("data", `worlds/${game.world.data.name}/adventures/${adventurePath}/${targetPath}`);
+          const fileObj = zip.file(path);
+          if (fileObj !== null) {
+            const img = await zip.file(path).async("uint8array");
+            const i = new File([img], filename);
+            await Helpers.UploadFile("data", `worlds/${game.world.data.name}/adventures/${adventurePath}/${targetPath}`, i, { bucket: null })
+            CONFIG.AIE.TEMPORARY.import[path] = true;
+          }
+          else {
+            Helpers.logger.debug(`Skipping file ${path} because zip.file(path) call was null`);
+          }
         } else {
           Helpers.logger.debug(`File already imported ${path}`);  
         }


### PR DESCRIPTION
1. Switching to not use entity but use documentName instead
2. Using the contents collection on Scene.data.tokens since array references for those were deprecated
3. Switching away from using Document._id to Document.id instead
4. Use updateEmbeddedDocuments instead of updateEmbeddedEntity